### PR TITLE
feat: 글 작성 시간 변경 기능 추가

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -18,7 +18,7 @@ export default async function Page() {
           title={title}
           spoiler={spoiler}
           isPrivate={isPrivate ?? false}
-          createdAt={new Date(createdAt).toISOString().slice(0, 10)}
+          createdAt={createdAt ? new Date(createdAt).toISOString().slice(0, 10) : ''}
         />
       ))}
     </div>

--- a/app/(root)/posts/[id]/(post)/page.tsx
+++ b/app/(root)/posts/[id]/(post)/page.tsx
@@ -21,10 +21,10 @@ export default async function Page({ params }: PostPageProps) {
       title={title}
       spoiler={spoiler}
       content={content}
-      createdAt={new Date(createdAt)
+      createdAt={createdAt ? new Date(createdAt)
         .toISOString()
         .slice(0, 10)
-        .replaceAll('-', '.')}
+        .replaceAll('-', '.') : ''}
       likeCount={likes.length}
     />
   );

--- a/app/(root)/posts/[id]/(post)/private/page.tsx
+++ b/app/(root)/posts/[id]/(post)/private/page.tsx
@@ -16,10 +16,10 @@ export default async function Page({ params }: PostPageProps) {
       title={title}
       spoiler={spoiler}
       content={content}
-      createdAt={new Date(createdAt)
+      createdAt={createdAt ? new Date(createdAt)
         .toISOString()
         .slice(0, 10)
-        .replaceAll('-', '.')}
+        .replaceAll('-', '.') : ''}
       likeCount={likes.length}
     />
   );

--- a/app/(root)/posts/[id]/edit/page.tsx
+++ b/app/(root)/posts/[id]/edit/page.tsx
@@ -11,8 +11,16 @@ async function handleSubmit(formData: FormData) {
   const content = formData.get('content')?.toString();
   const spoiler = formData.get('spoiler')?.toString();
   const isPrivate = Boolean(formData.get('isPrivate'));
+  const createdAtStr = formData.get('createdAt')?.toString();
+  const createdAt = createdAtStr ? new Date(createdAtStr) : undefined;
   if (id && title && content && spoiler) {
-    await PostsService.updatePost(id, { title, content, spoiler, isPrivate });
+    await PostsService.updatePost(id, {
+      title,
+      content,
+      spoiler,
+      isPrivate,
+      createdAt,
+    });
     revalidatePath('/');
     revalidatePath(`/posts/${id}`);
     revalidatePath(`/posts/${id}/private`);
@@ -32,7 +40,17 @@ export default async function Page({ params }: { params: { id: string } }) {
     throw new Error(`cannot find post id: ${params.id}`);
   }
 
-  const { title, content, spoiler, isPrivate } = post;
+  const { title, content, spoiler, isPrivate, createdAt } = post;
+
+  // datetime-local 형식: YYYY-MM-DDTHH:mm
+  const formatDateTimeLocal = (date: Date) => {
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  };
+
+  const createdAtValue = createdAt
+    ? formatDateTimeLocal(new Date(createdAt))
+    : undefined;
 
   return (
     <EditForm
@@ -41,6 +59,7 @@ export default async function Page({ params }: { params: { id: string } }) {
       spoiler={spoiler}
       content={content}
       isPrivate={isPrivate ?? false}
+      createdAt={createdAtValue}
       handleSubmit={handleSubmit}
     />
   );

--- a/app/(root)/write/page.tsx
+++ b/app/(root)/write/page.tsx
@@ -10,12 +10,15 @@ async function handleSubmit(formData: FormData) {
   const content = formData.get('content')?.toString();
   const spoiler = formData.get('spoiler')?.toString();
   const isPrivate = Boolean(formData.get('isPrivate'));
+  const createdAtStr = formData.get('createdAt')?.toString();
+  const createdAt = createdAtStr ? new Date(createdAtStr) : undefined;
   if (title && content && spoiler) {
     const { _id } = await PostsService.createPost({
       title,
       content,
       spoiler,
       isPrivate,
+      createdAt,
     });
     revalidatePath('/');
     redirect(`/posts/${_id}`);

--- a/app/_components/EditForm.tsx
+++ b/app/_components/EditForm.tsx
@@ -12,6 +12,7 @@ type Props = {
   title: string;
   spoiler: string;
   content: string;
+  createdAt?: string;
 };
 
 const EditForm = ({
@@ -21,6 +22,7 @@ const EditForm = ({
   spoiler,
   content: initialContent,
   isPrivate,
+  createdAt,
 }: Props) => {
   const [isPreview, setIsPreview] = useState(false);
   const [fileUploadCount, setFileUploadCount] = useState(0);
@@ -123,6 +125,16 @@ const EditForm = ({
           <span {...stylex.props(styles.toggleSwitch)} />
           <span {...stylex.props(styles.toggleText)}>비공개</span>
         </label>
+      </div>
+
+      <div {...stylex.props(styles.fieldGroup)}>
+        <label {...stylex.props(styles.label)}>작성 시간</label>
+        <input
+          {...stylex.props(styles.input)}
+          type="datetime-local"
+          name="createdAt"
+          defaultValue={createdAt}
+        />
       </div>
 
       <div {...stylex.props(styles.fieldGroup, styles.contentGroup)}>

--- a/app/_components/EditForm.tsx
+++ b/app/_components/EditForm.tsx
@@ -21,12 +21,13 @@ const EditForm = ({
   title,
   spoiler,
   content: initialContent,
-  isPrivate,
+  isPrivate: initialIsPrivate,
   createdAt,
 }: Props) => {
   const [isPreview, setIsPreview] = useState(false);
   const [fileUploadCount, setFileUploadCount] = useState(0);
   const [isFileUploading, setIsFileUploading] = useState(false);
+  const [isPrivateChecked, setIsPrivateChecked] = useState(initialIsPrivate);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef(initialContent);
 
@@ -120,9 +121,15 @@ const EditForm = ({
             {...stylex.props(styles.checkbox)}
             type="checkbox"
             name="isPrivate"
-            defaultChecked={isPrivate}
+            checked={isPrivateChecked}
+            onChange={(e) => setIsPrivateChecked(e.target.checked)}
           />
-          <span {...stylex.props(styles.toggleSwitch)} />
+          <span
+            {...stylex.props(
+              styles.toggleSwitch,
+              isPrivateChecked && styles.toggleSwitchChecked,
+            )}
+          />
           <span {...stylex.props(styles.toggleText)}>비공개</span>
         </label>
       </div>
@@ -253,9 +260,7 @@ const styles = stylex.create({
     position: 'relative',
     width: '48px',
     height: '24px',
-    backgroundColor: {
-      default: '#e5e7eb',
-    },
+    backgroundColor: '#e5e7eb',
     borderRadius: '12px',
     transition: 'background-color 0.2s ease',
     '::before': {
@@ -269,6 +274,22 @@ const styles = stylex.create({
       borderRadius: '50%',
       transition: 'transform 0.2s ease',
       boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+    },
+  },
+  toggleSwitchChecked: {
+    backgroundColor: '#6366f1',
+    '::before': {
+      content: '""',
+      position: 'absolute',
+      top: '2px',
+      left: '2px',
+      width: '20px',
+      height: '20px',
+      backgroundColor: 'white',
+      borderRadius: '50%',
+      transition: 'transform 0.2s ease',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+      transform: 'translateX(24px)',
     },
   },
   toggleText: {

--- a/app/_lib/posts/Post.model.ts
+++ b/app/_lib/posts/Post.model.ts
@@ -8,8 +8,9 @@ const postSchema = new Schema(
     isPrivate: { type: Boolean, required: true },
     likes: { type: [String], default: [] },
     tags: { type: [String], defualt: [] },
+    createdAt: { type: Date },
   },
-  { timestamps: true },
+  { timestamps: { createdAt: false, updatedAt: true } },
 );
 
 export const Post = models.Post

--- a/app/_lib/posts/Posts.service.ts
+++ b/app/_lib/posts/Posts.service.ts
@@ -29,10 +29,8 @@ export class PostsService {
       spoiler,
       isPrivate,
       tags,
+      createdAt: createdAt ?? new Date(),
     };
-    if (createdAt) {
-      postData.createdAt = createdAt;
-    }
     return Post.create(postData);
   }
 
@@ -47,18 +45,20 @@ export class PostsService {
   ) {
     await connectDB();
 
-    const updateData: Record<string, unknown> = {
-      title,
-      content,
-      spoiler,
-      isPrivate,
-      tags,
-    };
+    const post = await Post.findById(id);
+    if (!post) return null;
+
+    post.title = title ?? post.title;
+    post.content = content ?? post.content;
+    post.spoiler = spoiler ?? post.spoiler;
+    post.isPrivate = isPrivate ?? post.isPrivate;
+    post.tags = tags ?? post.tags;
     if (createdAt) {
-      updateData.createdAt = createdAt;
+      post.createdAt = createdAt;
     }
 
-    return Post.findByIdAndUpdate(id, updateData).lean().exec();
+    await post.save({ timestamps: !createdAt });
+    return post.toObject();
   }
 
   static async createLike(postId: string, liked: string) {

--- a/app/_lib/posts/Posts.service.ts
+++ b/app/_lib/posts/Posts.service.ts
@@ -20,9 +20,20 @@ export class PostsService {
     isPrivate,
     spoiler,
     tags = [],
+    createdAt,
   }: CreatePostDto) {
     await connectDB();
-    return Post.create({ title, content, spoiler, isPrivate, tags });
+    const postData: Record<string, unknown> = {
+      title,
+      content,
+      spoiler,
+      isPrivate,
+      tags,
+    };
+    if (createdAt) {
+      postData.createdAt = createdAt;
+    }
+    return Post.create(postData);
   }
 
   static async deletePost(id: string) {
@@ -32,19 +43,22 @@ export class PostsService {
 
   static async updatePost(
     id: string,
-    { title, content, spoiler, isPrivate, tags }: UpdatePostDto,
+    { title, content, spoiler, isPrivate, tags, createdAt }: UpdatePostDto,
   ) {
     await connectDB();
 
-    return Post.findByIdAndUpdate(id, {
+    const updateData: Record<string, unknown> = {
       title,
       content,
       spoiler,
       isPrivate,
       tags,
-    })
-      .lean()
-      .exec();
+    };
+    if (createdAt) {
+      updateData.createdAt = createdAt;
+    }
+
+    return Post.findByIdAndUpdate(id, updateData).lean().exec();
   }
 
   static async createLike(postId: string, liked: string) {

--- a/app/_lib/posts/dto/create-post.dto.ts
+++ b/app/_lib/posts/dto/create-post.dto.ts
@@ -4,4 +4,5 @@ export interface CreatePostDto {
   spoiler: string;
   isPrivate: boolean;
   tags?: string[];
+  createdAt?: Date;
 }

--- a/app/_lib/posts/dto/update-post.dto.ts
+++ b/app/_lib/posts/dto/update-post.dto.ts
@@ -4,4 +4,5 @@ export interface UpdatePostDto {
   spoiler?: string;
   isPrivate?: boolean;
   tags?: string[];
+  createdAt?: Date;
 }


### PR DESCRIPTION
## Summary

- 글 작성/수정 시 작성 시간(createdAt)을 임의로 변경할 수 있는 기능 추가
- datetime-local 입력 필드를 통해 사용자가 원하는 시간으로 설정 가능
- 새 글 작성 시 미입력하면 현재 시간으로 자동 설정, 수정 시 기존 시간 유지

## Changes

- `CreatePostDto`, `UpdatePostDto`에 `createdAt?: Date` 필드 추가
- `PostsService.createPost()`, `updatePost()`에서 createdAt 처리
- `EditForm` 컴포넌트에 작성 시간 입력 필드 추가
- `write/page.tsx`, `edit/page.tsx`에서 폼 데이터 처리